### PR TITLE
Fix incorrect cluster create command

### DIFF
--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -119,7 +119,7 @@ IPv6 address type is automatically used for your services and pods if
 
 ```bash
 # To create an IPv6 cluster
-kubectl apply -f examples/ipv6-cluster.yaml
+eksctl create cluster -f examples/ipv6-cluster.yaml
 ```
 
 If your cluster is configured to be dual-stack, you can set the IP address type


### PR DESCRIPTION
**What type of PR is this?**

documentation

**Which issue does this PR fix**:

n/a

**What does this PR do / Why do we need it**:

Content of `examples/ipv6-cluster.yaml` is for `eksctl` but not `kubectl`.

**If an issue # is not available please add repro steps and logs from aws-gateway-controller showing the issue**:

n/a

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!--
Test case added to lib/integration.sh
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**:
<!--
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.